### PR TITLE
Implement basic nav

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,11 @@
 
     <div class="page-content">
       <div class="wrapper">
+
+        <nav class="main-nav">
+          {% navigation %}
+        </nav>
+
         {{ content }}
       </div>
     </div>

--- a/_plugins/nav.rb
+++ b/_plugins/nav.rb
@@ -1,0 +1,72 @@
+module Jekyll
+
+  class ::Hash
+    def deep_merge(second)
+      merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+      self.merge(second, &merger)
+    end
+  end
+  
+  class NavTree < Liquid::Tag
+    def render(context)
+
+      site = context.registers[:site]
+      tree = {}
+
+      site.pages.each do |page|
+        path_parts = page.path.split('/')
+
+        subtree = path_parts.reverse.inject(page) { |a, n| { n => a } }
+        tree = tree.deep_merge(subtree)
+      end
+
+      return listify(tree, true)
+    end
+  end
+end
+
+def listify(tree, apply_blacklist = false)
+
+  blacklist = [
+    'css',
+    'feed.xml',
+    'index.html',
+    'contributing.md'
+  ]
+
+  output = '<ul>'
+  tree.each do |key, value|
+
+    if apply_blacklist && blacklist.include?(key)
+      next
+    end
+
+    if value.is_a?(Jekyll::Page)
+      if value.data.has_key? 'title'
+        output += list_itemify(value)
+      end
+    else
+      if value.has_key? 'index.md'
+        output += list_itemify(value['index.md'])
+        value = value.delete_if { |key, value| key == 'index.md' }
+
+        output += "<li>#{listify(value)}</li>"
+      end
+    end
+  end
+  output += '</ul>'
+end
+
+def list_itemify(page)
+  if !page.is_a?(Jekyll::Page)
+    ""
+  elsif page.data.has_key? 'nav_title'
+    "<li><a href='#{page.url}'>#{page.data['nav_title']}</a></li>"
+  elsif page.data.has_key? 'title'
+    "<li><a href='#{page.url}'>#{page.data['title']}</a></li>"
+  else
+    ""
+  end
+end
+ 
+Liquid::Template.register_tag("navigation", Jekyll::NavTree)

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -154,6 +154,7 @@ pre {
  * Wrapper
  */
 .wrapper {
+    position: relative;
     max-width: -webkit-calc(800px - (#{$spacing-unit} * 2));
     max-width:         calc(800px - (#{$spacing-unit} * 2));
     margin-right: auto;
@@ -223,4 +224,34 @@ div.feedback {
   border-top: solid 1px #ddd;
   color: #777;
   font-size: 0.9em;
+}
+
+nav.main-nav {
+  position: absolute;
+  top: 0;
+  left: -160px;
+  width: 160px;
+  padding-right: 1em;
+  margin-right: 1em;
+  margin-bottom: 1em;
+
+  ul {
+    margin-left: 0;
+    li {
+      list-style-type: none;
+      ul {
+        margin-left: 1em; 
+        li {
+          list-style-type: none;
+          ul li {
+            list-style-type: disc;
+          }
+        }
+      }
+    }
+  }
+}
+
+div.page-content {
+  min-height: 500px;
 }

--- a/incoming-ach/index.md
+++ b/incoming-ach/index.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Incoming ACH
+permalink: /incoming-ach/
+---
+
+Stuff

--- a/index.html
+++ b/index.html
@@ -6,12 +6,4 @@ layout: default
 
   <p>Welcome! This reference aspires to be a source of unbiased, (hopefully) helpful information about accepting payments online. Merchants and developers are the primary intended audience for this reference, but ideally it could be useful to anyone who works with online payments.</p>
 
-  <h2><a href="/payment-cards/pci-compliance/">PCI Compliance</a></h2>
-
-  <ul>
-    <li><a href="/payment-cards/pci-compliance/saqs/">List of SAQs</a>
-    <li><a href="/payment-cards/pci-compliance/integrations/">List of integrations and their SAQ eligibility</a>
-  </ul>
-
-  <h2><a href="/glossary/">Glossary of payments-related terms</a></h2>
 </div>

--- a/payment-cards/index.md
+++ b/payment-cards/index.md
@@ -1,0 +1,5 @@
+---
+layout: page
+title: Payment Cards
+permalink: /payment-cards/
+---

--- a/payment-cards/pci-compliance/integrations.md
+++ b/payment-cards/pci-compliance/integrations.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: The PCI burden of various integrations
+nav_title: Integrations
 permalink: /payment-cards/pci-compliance/integrations/
 ---
 

--- a/payment-cards/pci-compliance/saqs.md
+++ b/payment-cards/pci-compliance/saqs.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Self Assessment Questionnaires
+nav_title: SAQs
 permalink: /payment-cards/pci-compliance/saqs/
 ---
 


### PR DESCRIPTION
This implements a basic generated nav with some limitations:
- It's not responsive
- The CSS is sort of funky
- The blacklisting could be refactored into something taken from `_config.yml`

![screen shot 2015-05-15 at 2 30 06 pm](https://cloud.githubusercontent.com/assets/916028/7660642/9276b580-fb11-11e4-9d3e-8c4767849080.png)

:rotating_light: **(!)** Let me squash this branch into one commit before we merge.
