### PR TITLE
Fix mobile nav, make site wider, add grid system

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,11 +1,26 @@
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width initial-scale=1" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width initial-scale=1" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="description" content="{{ site.description }}">
+  <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+  <meta name="description" content="{{ site.description }}">
 
-    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+
+  <script>
+    window.onload = function () {
+      var coverNav = document.querySelector('.cover-nav');
+      var menuIcon = document.querySelector('.menu-icon');
+      menuIcon.addEventListener('click', function () {
+        var open = coverNav.style.display == 'block';
+        if (open) {
+          coverNav.style.display = 'none';
+        } else {
+          coverNav.style.display = 'block';
+        }
+      });
+    };
+  </script>
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,9 +13,8 @@
         </svg>
       </span>
 
-      <div class="trigger">
-        <a class="page-link" href="/contributing/">Contributing</a>
-      </div>
+      <a class="page-link" href="/contributing/">Contributing</a>
+
     </nav>
 
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,13 +5,26 @@
 
   <body>
 
+    <div class="cover-nav">
+      {% include nav.html %}
+    </div>
+
     {% include header.html %}
 
     <div class="page-content">
       <div class="wrapper">
-        {% include nav.html %}
 
-        {{ content }}
+        <div class="grid">
+          <div class="col-1-4">
+            <div class="aside-nav">
+              {% include nav.html %}
+            </div>
+          </div>
+          <div class="col-3-4">
+            {{ content }}
+          </div>
+        </div>
+
       </div>
     </div>
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -155,8 +155,8 @@ pre {
  */
 .wrapper {
     position: relative;
-    max-width: -webkit-calc(800px - (#{$spacing-unit} * 2));
-    max-width:         calc(800px - (#{$spacing-unit} * 2));
+    max-width: -webkit-calc(960px - (#{$spacing-unit} * 2));
+    max-width:         calc(960px - (#{$spacing-unit} * 2));
     margin-right: auto;
     margin-left: auto;
     padding-right: $spacing-unit;
@@ -164,8 +164,8 @@ pre {
     @extend %clearfix;
 
     @include media-query($on-laptop) {
-        max-width: -webkit-calc(800px - (#{$spacing-unit}));
-        max-width:         calc(800px - (#{$spacing-unit}));
+        max-width: -webkit-calc(960px - (#{$spacing-unit}));
+        max-width:         calc(960px - (#{$spacing-unit}));
         padding-right: $spacing-unit / 2;
         padding-left: $spacing-unit / 2;
     }
@@ -227,14 +227,6 @@ div.feedback {
 }
 
 nav.main-nav {
-  position: absolute;
-  top: 0;
-  left: -160px;
-  width: 160px;
-  padding-right: 1em;
-  margin-right: 1em;
-  margin-bottom: 1em;
-
   ul {
     margin-left: 0;
     margin-bottom: 0.2em;
@@ -245,6 +237,12 @@ nav.main-nav {
         margin-left: 1em; 
       }
     }
+  }
+}
+
+.aside-nav {
+  @include media-query($on-palm) {
+    display: none;
   }
 }
 

--- a/_sass/_grid.scss
+++ b/_sass/_grid.scss
@@ -1,0 +1,62 @@
+/* apply a natural box layout model to all elements, but allowing components to change */
+html {
+  box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
+}
+
+$pad: 20px;
+
+.grid {
+  background: white;
+  margin: 0 0 $pad 0;
+  
+  &:after {
+    /* Or @extend clearfix */
+    content: "";
+    display: table;
+    clear: both;
+  }
+}
+
+[class*='col-'] {
+  float: left;
+  padding-right: $pad;
+  .grid &:last-of-type {
+    padding-right: 0;
+  }
+}
+.col-2-3 {
+  width: 66.66%;
+}
+.col-1-3 {
+  width: 33.33%;
+}
+.col-1-2 {
+  width: 50%;
+}
+.col-1-4 {
+  width: 25%;
+}
+.col-1-8 {
+  width: 12.5%;
+}
+.col-3-4 {
+  width: 75%;
+}
+
+.col-1-4,
+.col-3-4 {
+  @include media-query($on-palm) {
+    width: 100%;
+  }
+}
+
+/* Opt-in outside padding */
+.grid-pad {
+  padding: $pad 0 $pad $pad;
+  [class*='col-']:last-of-type {
+    padding-right: $pad;
+  }
+}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -23,66 +23,66 @@
     }
 }
 
+.cover-nav {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  height: 100%;
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.9);
+  z-index: 5;
+  padding: 1em;
+  display: none;
+}
+
 .site-nav {
     float: right;
     line-height: 56px;
 
     .menu-icon {
-        display: none;
+      display: none;
     }
 
     .page-link {
-        color: $text-color;
-        line-height: $base-line-height;
+      color: $text-color;
+      line-height: $base-line-height;
 
-        // Gaps between nav items, but not on the first one
-        &:not(:first-child) {
-            margin-left: 20px;
-        }
+      // Gaps between nav items, but not on the first one
+      &:not(:first-child) {
+        margin-left: 20px;
+      }
     }
 
     @include media-query($on-palm) {
-        position: absolute;
-        top: 9px;
-        right: 30px;
-        background-color: $background-color;
-        border: 1px solid $grey-color-light;
-        border-radius: 5px;
-        text-align: right;
+      .menu-icon {
+        display: block;
+        float: right;
+        width: 36px;
+        height: 26px;
+        line-height: 0;
+        padding-top: 19px;
+        text-align: center;
 
-        .menu-icon {
-            display: block;
-            float: right;
-            width: 36px;
-            height: 26px;
-            line-height: 0;
-            padding-top: 10px;
-            text-align: center;
-
-            > svg {
-                width: 18px;
-                height: 15px;
-
-                path {
-                    fill: $grey-color-dark;
-                }
-            }
+        &:hover {
+          cursor: pointer;
+          > svg path {
+            fill: $grey-color-light;
+          }
         }
 
-        .trigger {
-            clear: both;
-            display: none;
-        }
+        > svg {
+          width: 18px;
+          height: 15px;
 
-        &:hover .trigger {
-            display: block;
-            padding-bottom: 5px;
+          path {
+            fill: $grey-color-dark;
+          }
         }
+      }
 
-        .page-link {
-            display: block;
-            padding: 5px 10px;
-        }
+      .page-link {
+        display: none;
+      }
     }
 }
 

--- a/css/main.scss
+++ b/css/main.scss
@@ -45,5 +45,6 @@ $on-laptop:        800px;
 @import
         "base",
         "layout",
+        "grid",
         "syntax-highlighting"
 ;


### PR DESCRIPTION
This PR:
- Adds a new mobile navigation that covers the whole screen. If merged, it will fix #29.
- Puts all pages on a very simple grid system.
- Makes the site a bit wider (800px -> 960px). The content, however, shrinks from 740px to 630px.

![screen shot 2015-05-25 at 5 46 35 pm](https://cloud.githubusercontent.com/assets/916028/7803499/0423f688-0306-11e5-9597-35a5d080dcf8.png)

![screen shot 2015-05-25 at 5 46 54 pm](https://cloud.githubusercontent.com/assets/916028/7803503/10fc830c-0306-11e5-8bd9-43a8501ebec3.png)
